### PR TITLE
Prevent touch command from always executing.

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -14,6 +14,7 @@ create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
 
 touch /etc/letsencrypt/{{ domainlist | join('.check /etc/letsencrypt/') }}.check:
   cmd.run:
+    - unless: test -f /etc/letsencrypt/{{ domainlist | join('.check && test -f /etc/letsencrypt/') }}.check
     - require:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
 


### PR DESCRIPTION
If the /etc/letsencrypt/<domain>.check files already exist, there is no need to re-execute the touch command on each state run.
