### PR TITLE
Cleaner approach

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -3,11 +3,20 @@
 
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
 
-{% for setname, domainlist in salt['pillar.get']('letsencrypt:domainsets').iteritems() %}
+{%
+  for setname, domainlist in salt['pillar.get'](
+    'letsencrypt:domainsets'
+  ).iteritems()
+%}
 create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
   cmd.run:
-    - unless: test -f /etc/letsencrypt/{{ domainlist | join('.check && test -f /etc/letsencrypt/') }}.check
-    - name: {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
+    - unless: >
+        test -f /etc/letsencrypt/{{
+          domainlist | join('.check && test -f /etc/letsencrypt/')
+        }}.check
+    - name: {{
+          letsencrypt.cli_install_dir
+        }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
     - cwd: {{ letsencrypt.cli_install_dir }}
     - require:
       - file: letsencrypt-config
@@ -23,7 +32,9 @@ touch /etc/letsencrypt/{{ domain }}.check:
 
 letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
   cron.present:
-    - name: {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
+    - name: {{
+          letsencrypt.cli_install_dir
+        }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
     - month: '*/2'
     - minute: random
     - hour: random

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -6,7 +6,7 @@
 {% for setname, domainlist in salt['pillar.get']('letsencrypt:domainsets').iteritems() %}
 create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
   cmd.run:
-    - unless: ls /etc/letsencrypt/{{ domainlist | join('.check /etc/letsencrypt/') }}.check
+    - unless: test -f /etc/letsencrypt/{{ domainlist | join('.check && test -f /etc/letsencrypt/') }}.check
     - name: {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
     - cwd: {{ letsencrypt.cli_install_dir }}
     - require:

--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -5,25 +5,29 @@
 {% import_yaml 'letsencrypt/defaults.yaml' as default_settings %}
 
 {##
-Setup variable using grains['os_family'] based logic, only add key:values here
-that differ from whats in defaults.yaml
+Setup variable using grains['os_family'] based logic, only add key:values
+here that differ from whats in defaults.yaml
 ##}
-{% set os_family_map = salt['grains.filter_by']({
-        'Debian': {},
-        'Suse': {},
-        'Arch': {},
-        'RedHat': {},
-  }
-  , grain="os_family"
-  , merge=salt['pillar.get']('letsencrypt:lookup'))
+{%
+  set os_family_map = salt['grains.filter_by'](
+    {
+      'Debian': {},
+      'Suse': {},
+      'Arch': {},
+      'RedHat': {},
+    },
+    grain="os_family",
+    merge=salt['pillar.get']('letsencrypt:lookup')
+  )
 %}
 {## Merge the flavor_map to the default settings ##}
 {% do default_settings.letsencrypt.update(os_family_map) %}
 
 {## Merge in letsencrypt:lookup pillar ##}
-{% set letsencrypt = salt['pillar.get'](
-        'letsencrypt',
-        default=default_settings.letsencrypt,
-        merge=True
-    )
+{%
+  set letsencrypt = salt['pillar.get'](
+    'letsencrypt',
+    default=default_settings.letsencrypt,
+    merge=True
+  )
 %}


### PR DESCRIPTION
Includes a few minor improvements to the state layout. Doesn't change functionality, but makes the state more readable by having <80 character lines everywhere, indentation consistency improvements, use of salt['pillar.get'](...) instead of pillar[...], a replacement for one of the "{{ domainlist | join('.check /etc/letsencrypt/') }}" statements, etc.

Also replaces 'ls' with 'test' for testing files to improve reliability, and adds the "unless: test -f /etc/letsencrypt/{{ domain }}.check" line to the touch command to prevent unnecessarily executing. Makes my previous pull request redundant if this is accepted.
