### PR TITLE
Fix domains in multiple certs / Cronjob based on remaining cert validity

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -3,32 +3,36 @@
 
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
 
+
+/usr/local/bin/check_letsencrypt_cert.sh:
+  file.managed:
+    - mode: 755
+    - contents: |
+        #!/bin/bash
+
+        FIRST_CERT=$1
+
+        for DOMAIN in "$@"
+        do
+            openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -noout -text | grep DNS:${DOMAIN} > /dev/null || exit 1
+        done
+
 {%
   for setname, domainlist in salt['pillar.get'](
     'letsencrypt:domainsets'
   ).iteritems()
 %}
+
 create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
   cmd.run:
-    - unless: >
-        test -f /etc/letsencrypt/{{
-          domainlist | join('.check && test -f /etc/letsencrypt/')
-        }}.check
+    - unless: /usr/local/bin/check_letsencrypt_cert.sh {{ domainlist|join(' ') }}
     - name: {{
           letsencrypt.cli_install_dir
         }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
     - cwd: {{ letsencrypt.cli_install_dir }}
     - require:
       - file: letsencrypt-config
-
-{% for domain in domainlist %}
-touch /etc/letsencrypt/{{ domain }}.check:
-  file.touch:
-    - name: /etc/letsencrypt/{{ domain }}.check
-    - unless: test -f /etc/letsencrypt/{{ domain }}.check
-    - require:
-      - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
-{% endfor %}
+      - file: /usr/local/bin/check_letsencrypt_cert.sh
 
 letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
   cron.present:

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -16,6 +16,11 @@
         do
             openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -noout -text | grep DNS:${DOMAIN} > /dev/null || exit 1
         done
+        CERT=$(date -d "$(openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -enddate -noout | cut -d'=' -f2)" "+%s")
+        CURRENT=$(date "+%s")
+        REMAINING=$((($CERT - $CURRENT) / 60 / 60 / 24))
+        [ "$REMAINING" -gt "30" ] || exit 1
+        echo Domains $@ are in cert and cert is valid for $REMAINING days
 
 {%
   for setname, domainlist in salt['pillar.get'](
@@ -36,13 +41,13 @@ create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
 
 letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
   cron.present:
-    - name: {{
+    - name: /usr/local/bin/check_letsencrypt_cert.sh {{ domainlist|join(' ') }} > /dev/null ||{{
           letsencrypt.cli_install_dir
         }}/letsencrypt-auto -d {{ domainlist|join(' -d ') }} certonly
-    - month: '*/2'
+    - month: '*'
     - minute: random
     - hour: random
-    - daymonth: random
+    - dayweek: '*'
     - identifier: letsencrypt-{{ setname }}-{{ domainlist[0] }}
     - require:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}


### PR DESCRIPTION
The '.check' file approach fails if you have domains in multiple certs. E.g:

```
webserver:
  - somehost.com
  - www.somehost.com

mailserver:
  - mail.somehost.com
  - somehost.com
```

Because the check file state exists twice and the check itself is also ambigious.

I now added a script that does two things:
- check for every domain if it is in the domainset. If not: exit 1
- check if the validity of the cert is at least 30 days. If not: exit 1

This script is then used to: 
- avoid cert creation in salt state if both conditions above are fulfilled
- avoid cert creation / renewal in cronjob if both conditions above are fulfilled

The cronjob now runs daily.

Some comments please before I merge this back into the formula. There are no requirements besides openssl and a bash interpreter (which is why I haven't stated them explicitly).
