### PR TITLE
Add support for fullchain-privkey.pem file creation and update

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -24,20 +24,9 @@
 
 /usr/local/bin/renew_letsencrypt_cert.sh:
   file.managed:
+    - template: jinja
+    - source: salt://letsencrypt/files/renew_letsencrypt_cert.sh.jinja
     - mode: 755
-    - contents: |
-        #!/bin/bash
-        for DOMAIN in "$@"
-        do
-            if ! /usr/local/bin/check_letsencrypt_cert.sh "$DOMAIN" > /dev/null
-            then
-                {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d "$DOMAIN" certonly || exit 1
-                cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem \
-                    /etc/letsencrypt/live/${DOMAIN}/privkey.pem \
-                    > /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-                chmod 600 /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
-            fi
-        done
     - require:
       - file: /usr/local/bin/check_letsencrypt_cert.sh
 

--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -1,0 +1,13 @@
+#!/bin/bash
+{% from "letsencrypt/map.jinja" import letsencrypt with context %}
+for DOMAIN in "$@"
+do
+    if ! /usr/local/bin/check_letsencrypt_cert.sh "$DOMAIN" > /dev/null
+    then
+        {{ letsencrypt.cli_install_dir }}/letsencrypt-auto -d "$DOMAIN" certonly || exit 1
+        cat /etc/letsencrypt/live/${DOMAIN}/fullchain.pem \
+            /etc/letsencrypt/live/${DOMAIN}/privkey.pem \
+            > /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
+        chmod 600 /etc/letsencrypt/live/${DOMAIN}/fullchain-privkey.pem || exit 1
+    fi
+done


### PR DESCRIPTION
This adds a step to create a `fullchain-priv.pem` PEM file for each domain, which can then be used with Pound (load balancer and SSL termination).

It also updates the `fullchain-priv.pem` file every time the domains are renewed.
