### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,18 +21,18 @@ Available states
 Installs and configures the letsencrypt cli from git, creates the requested certificates and installs renewal cron job.
 This is a shortcut for letsencrypt.install letsencrypt.config and letsencrypt.domains .
 
-``install``
+``letsencrypt.install``
 -----------
 
 Only installs the letsencrypt client. Currently the letsencrypt-auto method is used. This will create a virtualenv in the /root/.config/ directory.
 The installation method will be replaced by using packages, as default as soon as they ara stable and available for all major platforms.
 
-``config``
+``letsencrypt.config``
 ----------
 
 Manages /etc/letsencrypt/cli.ini config file.
 
-``domains``
+``letsencrypt.domains``
 -----------
 Creates a certificate with the domains in each domain set (letsencrypt:domainsets in pillar). Letsencrypt uses a relatively short validity of 90 days.
 Therefore, a cron job for automatic renewal every 60 days is installed for each domain set as well.


### PR DESCRIPTION
I don't know if this is intentional or not, but it seems other than the first, the other states should be prefixed with "letsencript." to match the style used in other formulas.
