### PR TITLE
single quotes are escaped double quotes in the variable. The update s…

### DIFF
--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -10,7 +10,7 @@ done
 
 if ! /usr/local/bin/check_letsencrypt_cert.sh "$@" > /dev/null
 then
-    {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly "$JOINED" || exit 1
+    {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly $JOINED || exit 1
     cat /etc/letsencrypt/live/${COMMON_NAME}/fullchain.pem \
         /etc/letsencrypt/live/${COMMON_NAME}/privkey.pem \
         > /etc/letsencrypt/live/${COMMON_NAME}/fullchain-privkey.pem || exit 1


### PR DESCRIPTION
crontab update script does not properly handle arguments, passing them with single quotes

error:

> letsencrypt: error: unrecognized arguments:  -d mydomain.ru

```
/renew_letsencrypt_cert.sh mydomain.ru
+ COMMON_NAME=linkexplorer.ru
+ JOINED=
+ for DOMAIN in '"$@"'
+ JOINED+=' -d linkexplorer.ru'
+ /usr/local/bin/check_letsencrypt_cert.sh mydomain.ru
+ /opt/letsencrypt/letsencrypt-auto certonly ' -d mydomain.ru'
usage: 
  letsencrypt-auto [SUBCOMMAND] [options] [-d domain] [-d domain] ...

Certbot can obtain and install HTTPS/TLS/SSL certificates.  By default,
it will attempt to use a webserver both for obtaining and installing the
cert. Major SUBCOMMANDS are:

  (default) run        Obtain & install a cert in your current webserver
  certonly             Obtain cert, but do not install it (aka "auth")
  install              Install a previously obtained cert in a server
  renew                Renew previously obtained certs that are near expiry
  revoke               Revoke a previously obtained certificate
  register             Perform tasks related to registering with the CA
  rollback             Rollback server configuration changes made during install
  config_changes       Show changes made to server config during installation
  plugins              Display information about installed plugins
letsencrypt: error: unrecognized arguments:  -d mydomain.ru
+ exit 1
```
