### PR TITLE
Fix letsencrypt-client-git state

### DIFF
--- a/letsencrypt/install.sls
+++ b/letsencrypt/install.sls
@@ -7,3 +7,4 @@ letsencrypt-client-git:
   git.latest:
     - name: https://github.com/letsencrypt/letsencrypt
     - target: {{ letsencrypt.cli_install_dir }}
+    - force_reset: True


### PR DESCRIPTION
I get this error on letsencrypt-client-git state In Salt: 2016.3.2 :

``` shell
[INFO    ] Executing command ['git', 'merge-base', '--is-ancestor', '5650560459920ab53dd88e4733e361bbcef837d9', '1e41641b49af00589cf41169b699bb8b4e4cfc45'] in directory '/opt/letsencrypt'
[ERROR   ] Repository would be updated to 1e41641, but this is not a fast-forward merge. Set 'force_reset' to True to force this update.
[INFO    ] Completed state [https://github.com/letsencrypt/letsencrypt] at time 06:56:38.789886 duration_in_ms=1575.345
```

Set 'force_reset' to True should fix it
