### PR TITLE
Define check_letsencrypt_cert.sh in a file

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -7,20 +7,7 @@
 /usr/local/bin/check_letsencrypt_cert.sh:
   file.managed:
     - mode: 755
-    - contents: |
-        #!/bin/bash
-
-        FIRST_CERT=$1
-
-        for DOMAIN in "$@"
-        do
-            openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -noout -text | grep DNS:${DOMAIN} > /dev/null || exit 1
-        done
-        CERT=$(date -d "$(openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -enddate -noout | cut -d'=' -f2)" "+%s")
-        CURRENT=$(date "+%s")
-        REMAINING=$((($CERT - $CURRENT) / 60 / 60 / 24))
-        [ "$REMAINING" -gt "30" ] || exit 1
-        echo Domains $@ are in cert and cert is valid for $REMAINING days
+    - source: salt://letsencrypt/files/check_letsencrypt_cert.sh
 
 /usr/local/bin/renew_letsencrypt_cert.sh:
   file.managed:

--- a/letsencrypt/files/check_letsencrypt_cert.sh
+++ b/letsencrypt/files/check_letsencrypt_cert.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+FIRST_CERT=$1
+
+for DOMAIN in "$@"
+do
+    openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -noout -text | grep DNS:${DOMAIN} > /dev/null || exit 1
+done
+CERT=$(date -d "$(openssl x509 -in /etc/letsencrypt/live/$1/cert.pem -enddate -noout | cut -d'=' -f2)" "+%s")
+CURRENT=$(date "+%s")
+REMAINING=$((($CERT - $CURRENT) / 60 / 60 / 24))
+[ "$REMAINING" -gt "30" ] || exit 1
+echo Domains $@ are in cert and cert is valid for $REMAINING days


### PR DESCRIPTION
Now that there is a renew_letsencrypt_cert.sh.jinja file it makes sense to also split out the check script.
Additionally that would make it easier to edit it.