### PR TITLE
Add support to use certbot's package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,103 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a packager
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.kitchen
+.kitchen.local.yml
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,94 @@
+---
+driver:
+  name: docker
+
+driver_config:
+  use_sudo: false
+  privileged: true
+
+platforms:
+  - name: debian-9
+    driver_config:
+      provision_command:
+        - mkdir -p /run/sshd
+        - apt-get install git -y
+      run_command: /lib/systemd/systemd
+  - name: centos-7
+    driver_config:
+      image: saltstack/centos-7-minimal
+      provision_command:
+        - mkdir -p /run/sshd
+        - yum install git -y
+      run_command: /lib/systemd/systemd
+
+provisioner:
+  name: salt_solo
+  log_level: info
+  require_chef: false
+  salt_version: latest
+  formula: letsencrypt
+  salt_copy_filter:
+    - .kitchen
+    - .git
+
+  dependencies:
+    - name: apt
+      repo: git
+      source: https://github.com/saltstack-formulas/apt-formula.git
+
+  pillars:
+    top.sls:
+      base:
+        '*':
+          - apt
+          - letsencrypt
+    apt.sls:
+      apt:
+        repositories:
+          #####
+          letsencrypt-backports:
+            distro: stretch-backports
+            url: http://deb.debian.org/debian
+            comps: [main]
+        preferences:
+          letsencrypt-backports:
+            pin: release a=stretch-backports 
+            priority: 640
+    #epel.sls:
+    #  epel:
+    #    disabled: false
+    letsencrypt.sls:
+      letsencrypt:
+        use_package: true
+        config: |
+          server: https://acme-staging.api.letsencrypt.org/directory
+          email: saltstack-letsencrypt-formula@example.com
+          authenticator: webroot
+          webroot-path: /var/www/html
+          agree-tos: true
+          renew-by-default: true
+
+suites:
+  - name: deb
+    excludes:
+      - centos-7
+    provisioner:
+      state_top:
+        base:
+          '*':
+            - apt.repositories
+            - apt.preferences
+            - apt.update
+            - letsencrypt.install
+            - letsencrypt.service
+            - letsencrypt.config
+  - name: rpm
+    excludes:
+      - debian-9
+    provisioner:
+      state_top:
+        base:
+          '*':
+            # - epel
+            - letsencrypt.install
+            - letsencrypt.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+cache: bundler
+language: ruby
+
+services:
+  - docker
+
+before_install:
+  - bundle install
+
+script: bundle exec kitchen verify

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "test-kitchen", '>=1.20.0'
+gem "kitchen-docker"
+gem "kitchen-salt", ">=0.1.0"
+gem "kitchen-inspec"
+

--- a/README.rst
+++ b/README.rst
@@ -18,23 +18,31 @@ Available states
 ``letsencrypt``
 ---------------
 
-Installs and configures the letsencrypt cli from git, creates the requested certificates and installs renewal cron job.
-This is a shortcut for letsencrypt.install letsencrypt.config and letsencrypt.domains .
+This is a shortcut for letsencrypt.install letsencrypt.config and letsencrypt.domains.
 
-If `use_package` is `True`, the formula will try to install the package from your Distro's repo. Keep in mind that most distros
-don't have a package available by default: Ie, current Debian (Stretch) requires a backports repo installed. Centos 7 requires
-EPEL, etc. This formula **DOES NOT** manage these repositories. Use the `apt-formula <https://github.com/saltstack-formulas/apt-formula>`_
+If `use_package` is `True` (the default), the formula will try to install the *certbot* package from your Distro's repo.
+Keep in mind that most distros don't have a package available by default: Ie, current Debian (Stretch) requires a backports repo installed.
+Centos 7 requires EPEL, etc. This formula **DOES NOT** manage these repositories. Use the `apt-formula <https://github.com/saltstack-formulas/apt-formula>`_
 or the `epel-formula <https://github.com/saltstack-formulas/epel-formula`_ to manage them.
 
-If you set `use_package` to `True`, it will default to Python3's certbot package (where possible), with Apache as the default Webserver to manage.
+If `use_package` is `False` it installs and configures the letsencrypt cli from git, creates the requested certificates and installs renewal cron job.
 
+** WARNING **
+If you set `use_package` to `True`, it will:
+
+* Default to Python3's certbot package (where possible), with Apache as the default Webserver to manage.
+* Delete all certbot's crons if they exist from a previous git-based installation (as the package uses a
+  systemd's timer unit to renew all the certs)
+* Delete git-based installation's scripts (usually installed under /usr/local/bin) if they still exist declared in
+  *letsencrypt*'s pillar.
+* As a safety meassure, if there's an /opt/letsencrypt directory from a git-based installation, it will be left
+  untouched, but unused.
 To check dependencies to use the package for your distro, check https://certbot.eff.org/all-instructions.
 
 ``letsencrypt.install``
 -----------------------
 
-Only installs the letsencrypt client. Currently the letsencrypt-auto method is used. This will create a virtualenv in the /root/.config/ directory.
-The installation method will be replaced by using packages, as default as soon as they ara stable and available for all major platforms.
+Only installs the letsencrypt client (see above).
 
 ``letsencrypt.config``
 ----------------------

--- a/README.rst
+++ b/README.rst
@@ -21,18 +21,28 @@ Available states
 Installs and configures the letsencrypt cli from git, creates the requested certificates and installs renewal cron job.
 This is a shortcut for letsencrypt.install letsencrypt.config and letsencrypt.domains .
 
+If `use_package` is `True`, the formula will try to install the package from your Distro's repo. Keep in mind that most distros
+don't have a package available by default: Ie, current Debian (Stretch) requires a backports repo installed. Centos 7 requires
+EPEL, etc. This formula **DOES NOT** manage these repositories. Use the `apt-formula <https://github.com/saltstack-formulas/apt-formula>`_
+or the `epel-formula <https://github.com/saltstack-formulas/epel-formula`_ to manage them.
+
+If you set `use_package` to `True`, it will default to Python3's certbot package (where possible), with Apache as the default Webserver to manage.
+
+To check dependencies to use the package for your distro, check https://certbot.eff.org/all-instructions.
+
 ``letsencrypt.install``
------------
+-----------------------
 
 Only installs the letsencrypt client. Currently the letsencrypt-auto method is used. This will create a virtualenv in the /root/.config/ directory.
 The installation method will be replaced by using packages, as default as soon as they ara stable and available for all major platforms.
 
 ``letsencrypt.config``
-----------
+----------------------
 
 Manages /etc/letsencrypt/cli.ini config file.
 
 ``letsencrypt.domains``
------------
+-----------------------
+
 Creates a certificate with the domains in each domain set (letsencrypt:domainsets in pillar). Letsencrypt uses a relatively short validity of 90 days.
 Therefore, a cron job for automatic renewal every 60 days is installed for each domain set as well.

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -4,6 +4,5 @@ letsencrypt:
   use_package: true
   pkg: python-certbot-apache
   cli_install_dir: /opt/letsencrypt
-  add_individual_crons: false
   post_renew:
     cmds:

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 letsencrypt:
+  use_package: true
+  pkg: python-certbot-apache
   cli_install_dir: /opt/letsencrypt
+  add_individual_crons: false
   post_renew:
     cmds:

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -2,7 +2,8 @@
 # vim: ft=yaml
 letsencrypt:
   use_package: true
-  pkg: python-certbot-apache
+  pkgs: 
+    - python-certbot-apache
   cli_install_dir: /opt/letsencrypt
   post_renew:
     cmds:

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -57,7 +57,7 @@ create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
 
 # Letsencrpyt package uses a systemd service/timer combination
 # or recommends to renew twice a day 
-  {% if not letsencrypt.package %}
+  {% if not letsencrypt.use_package %}
 
 # domainlist[0] represents the "CommonName", and the rest
 # represent SubjectAlternativeNames

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -5,7 +5,7 @@
 
 {% if letsencrypt.use_package %}
   # Renew checks if the cert exists and needs to be renewed
-  {% set check_cert_cmd = '/usr/bin/certbot renew' %}
+  {% set check_cert_cmd = '/usr/bin/certbot renew --cert-name' %}
   {% set renew_cert_cmd = '/usr/bin/certbot renew' %}
   {% set old_check_cert_cmd_state = 'absent' %}
   {% set old_renew_cert_cmd_state = 'absent' %}

--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -46,7 +46,9 @@ create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
   cmd.run:
     - unless: {{ check_cert_cmd }} {{ domainlist|join(' ') }}
     - name: {{ create_cert_cmd }} --quiet -d {{ domainlist|join(' -d ') }} certonly --non-interactive
+      {% if not letsencrypt.use_package %}
     - cwd: {{ letsencrypt.cli_install_dir }}
+      {% endif %}
     - require:
       {% if letsencrypt.use_package %}
       - pkg: letsencrypt-client

--- a/letsencrypt/init.sls
+++ b/letsencrypt/init.sls
@@ -4,4 +4,5 @@
 include:
   - letsencrypt.install
   - letsencrypt.config
+  - letsencrypt.service
   - letsencrypt.domains

--- a/letsencrypt/install.sls
+++ b/letsencrypt/install.sls
@@ -3,8 +3,13 @@
 
 {% from "letsencrypt/map.jinja" import letsencrypt with context %}
 
-letsencrypt-client-git:
+letsencrypt-client:
+  {% if letsencrypt.use_package %}
+  pkg.installed:
+    - name: {{ letsencrypt.pkg }}
+  {% else %}
   git.latest:
     - name: https://github.com/letsencrypt/letsencrypt
     - target: {{ letsencrypt.cli_install_dir }}
     - force_reset: True
+  {% endif %}

--- a/letsencrypt/install.sls
+++ b/letsencrypt/install.sls
@@ -6,7 +6,7 @@
 letsencrypt-client:
   {% if letsencrypt.use_package %}
   pkg.installed:
-    - name: {{ letsencrypt.pkg }}
+    - pkgs: {{ letsencrypt.pkgs }}
   {% else %}
   git.latest:
     - name: https://github.com/letsencrypt/letsencrypt

--- a/letsencrypt/map.jinja
+++ b/letsencrypt/map.jinja
@@ -2,33 +2,15 @@
 # vim: ft=jinja
 
 {## Start with  defaults from defaults.sls ##}
-{% import_yaml 'letsencrypt/defaults.yaml' as default_settings %}
+{% import_yaml 'letsencrypt/defaults.yaml' as defaults %}
+{% import_yaml 'letsencrypt/osfamilymap.yaml' as osfamilymap %}
 
-{##
-Setup variable using grains['os_family'] based logic, only add key:values
-here that differ from whats in defaults.yaml
-##}
-{%
-  set os_family_map = salt['grains.filter_by'](
-    {
-      'Debian': {},
-      'Suse': {},
-      'Arch': {},
-      'RedHat': {},
-      'FreeBSD': {},
-    },
-    grain="os_family",
-    merge=salt['pillar.get']('letsencrypt:lookup')
-  )
-%}
-{## Merge the flavor_map to the default settings ##}
-{% do default_settings.letsencrypt.update(os_family_map) %}
-
-{## Merge in letsencrypt:lookup pillar ##}
-{%
-  set letsencrypt = salt['pillar.get'](
-    'letsencrypt',
-    default=default_settings.letsencrypt,
-    merge=True
-  )
+{% set letsencrypt = salt['grains.filter_by'](
+    defaults,
+    merge = salt['grains.filter_by'](
+        osfamilymap,
+        grain='os_family',
+        merge = salt['pillar.get']('letsencrypt', {}),
+    ),
+    base='letsencrypt')
 %}

--- a/letsencrypt/osfamilymap.yaml
+++ b/letsencrypt/osfamilymap.yaml
@@ -1,2 +1,3 @@
 RedHat:
-  pkg: python2-certbot-apache
+  pkgs:
+    - python2-certbot-apache

--- a/letsencrypt/osfamilymap.yaml
+++ b/letsencrypt/osfamilymap.yaml
@@ -1,0 +1,2 @@
+RedHat:
+  pkg: python2-certbot-apache

--- a/letsencrypt/service.sls
+++ b/letsencrypt/service.sls
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "letsencrypt/map.jinja" import letsencrypt with context %}
+
+{% if letsencrypt.use_package %}
+letsencrypt-service-timer:
+  service.running:
+    - name: certbot.timer
+    - enable: true
+    - watch:
+      - pkg: letsencrypt-client
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,8 @@
 letsencrypt:
   use_package: true                              # Install using packages instead of git
-  pkg: python-certbot-apache                     # Package name to use. Check https://certbot.eff.org/all-instructions
-                                                 # to find the correct name for the variant you want to use.
+  pkgs:                                          # A list of package/s to install. Check https://certbot.eff.org/all-instructions
+    - python-certbot-apache                      # to find the correct name for the variant you want to use. Usually, you'll
+                                                 # need a single one, but you can also add other plugins here
 
   cli_install_dir: /opt/letsencrypt              # Only used for the git install method
   post_renew:

--- a/pillar.example
+++ b/pillar.example
@@ -2,10 +2,8 @@ letsencrypt:
   use_package: true                              # Install using packages instead of git
   pkg: python-certbot-apache                     # Package name to use. Check https://certbot.eff.org/all-instructions
                                                  # to find the correct name for the variant you want to use.
-  add_individual_crons: false                    # certbot's package uses a systemd's timer unit to try to renew the
-                                                 # certificates twice a day, so crons are not needed anymore.
 
-  cli_install_dir: /opt/letsencrypt
+  cli_install_dir: /opt/letsencrypt              # Only used for the git install method
   post_renew:
     cmds:
 

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,14 @@
 letsencrypt:
+  use_package: true                              # Install using packages instead of git
+  pkg: python-certbot-apache                     # Package name to use. Check https://certbot.eff.org/all-instructions
+                                                 # to find the correct name for the variant you want to use.
+  add_individual_crons: false                    # certbot's package uses a systemd's timer unit to try to renew the
+                                                 # certificates twice a day, so crons are not needed anymore.
+
+  cli_install_dir: /opt/letsencrypt
+  post_renew:
+    cmds:
+
   config: |
     server = https://acme-v01.api.letsencrypt.org/directory
     email = webmaster@example.com


### PR DESCRIPTION
This PR adds support to use distro-based certbot's packages instead of downloading it with git.

The old behaviour is still available, if setting `use_package: false` in the pillar.

Certbot's packages manages the renewal through a systemd's timer unit, so added support for that too.

Added a `.kitchen.yml` file for Debian and Centos testing. (Will push tests in another PR.)

This PR should close #29, #38 