### PR TITLE
Revert "Fixing if condition to renew certificates properly"

### DIFF
--- a/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
+++ b/letsencrypt/files/renew_letsencrypt_cert.sh.jinja
@@ -8,7 +8,7 @@ do
     JOINED+=" -d $DOMAIN"
 done
 
-if /usr/local/bin/check_letsencrypt_cert.sh "$@" > /dev/null
+if ! /usr/local/bin/check_letsencrypt_cert.sh "$@" > /dev/null
 then
     {{ letsencrypt.cli_install_dir }}/letsencrypt-auto certonly $JOINED --non-interactive || exit 1
     cat /etc/letsencrypt/live/${COMMON_NAME}/fullchain.pem \


### PR DESCRIPTION
Reverts saltstack-formulas/letsencrypt-formula#42

The proper fix to the checks was fixed in #47, and as mentioned in #50, the negation is required in the check. My bad.

This PR closes #50. 