### PR TITLE
Options comments

### DIFF
--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -5,13 +5,21 @@ letsencrypt:
   pkgs:
     - python-certbot-apache
   service: certbot.timer
-  cli_install_dir: /opt/letsencrypt
-  #version: 0.30.x  # If use_package: false and if you want to have specific version of certbot you can enable it. The value should match a certbot/certbot branch.
+  # Only used for the git install method (use_package: false)
+  #cli_install_dir: /opt/letsencrypt
+  # Only used for the git install method (use_package: false). If you want to
+  # have specific version of certbot you can enable it. The version value
+  # should match a certbot/certbot branch
+  #version: 0.30.x
   config_dir:
     path: /etc/letsencrypt
     user: root
     group: root
     mode: 755
+  # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
+  # run. For more fine grain control, consider placing scritps in the pre,
+  # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For
+  # more information, see: https://certbot.eff.org/docs/using.html#renewal
   post_renew:
     cmds:
   cron:

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -17,7 +17,7 @@ letsencrypt:
     group: root
     mode: 755
   # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
-  # run. For more fine grain control, consider placing scritps in the pre,
+  # run. For more fine grain control, consider placing scripts in the pre,
   # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For
   # more information, see: https://certbot.eff.org/docs/using.html#renewal
   post_renew:

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -6,7 +6,7 @@ letsencrypt:
     - python-certbot-apache
   service: certbot.timer
   # Only used for the git install method (use_package: false)
-  #cli_install_dir: /opt/letsencrypt
+  cli_install_dir: /opt/letsencrypt
   # Only used for the git install method (use_package: false). If you want to
   # have specific version of certbot you can enable it. The version value
   # should match a certbot/certbot branch

--- a/pillar.example
+++ b/pillar.example
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 letsencrypt:
-
   # Install using packages instead of git
   use_package: true
-
   # A list of package/s to install. To find the correct name for the variant
   # you want to use, check https://certbot.eff.org/all-instructions
   # Usually, you'll need a single one, but you can also add other plugins here.
   pkgs:
     - python-certbot-apache
-
-      # Only used for the git install method
+  # Only used for the git install method (use_package: false)
   cli_install_dir: /opt/letsencrypt
-
-  # If use_package: false and if you want to have specific version of certbot
-  # you can enable it. The version value should match a certbot/certbot branch.
-  #version: 0.26.x
-
+  # Only used for the git install method (use_package: false). If you want to
+  # have specific version of certbot you can enable it. The version value
+  # should match a certbot/certbot branch.
+  version: 0.30.x
   config: |
     server = https://acme-v01.api.letsencrypt.org/directory
     email = webmaster@example.com
@@ -25,13 +21,11 @@ letsencrypt:
     webroot-path = /var/lib/www
     agree-tos = True
     renew-by-default = True
-
   config_dir:
     path: /etc/letsencrypt
     user: root
     group: root
     mode: 755
-
   domainsets:
     www:
       - example.com
@@ -42,7 +36,6 @@ letsencrypt:
       - mail.example.com
     intranet:
       - intranet.example.com
-
   # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
   # run. For more fine grain control, consider placing scritps in the pre,
   # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For
@@ -51,7 +44,6 @@ letsencrypt:
     cmds:
       - service nginx reload
       - service haproxy reload
-
   cron:
     minute: 10
     hour: 2

--- a/pillar.example
+++ b/pillar.example
@@ -1,12 +1,22 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
 letsencrypt:
-  use_package: true                              # Install using packages instead of git
-  pkgs:                                          # A list of package/s to install. Check https://certbot.eff.org/all-instructions
-    - python-certbot-apache                      # to find the correct name for the variant you want to use. Usually, you'll
-                                                 # need a single one, but you can also add other plugins here
 
-  cli_install_dir: /opt/letsencrypt              # Only used for the git install method
-  version: 0.26.x                                # if use_packe false and if you want to have specific version
-                                                 # of certbot you can enable it without version git.latest is used
+  # Install using packages instead of git
+  use_package: true
+
+  # A list of package/s to install. To find the correct name for the variant
+  # you want to use, check https://certbot.eff.org/all-instructions
+  # Usually, you'll need a single one, but you can also add other plugins here.
+  pkgs:
+    - python-certbot-apache
+
+      # Only used for the git install method
+  cli_install_dir: /opt/letsencrypt
+
+  # If use_package: false and if you want to have specific version of certbot
+  # you can enable it. The version value should match a certbot/certbot branch.
+  #version: 0.26.x
 
   config: |
     server = https://acme-v01.api.letsencrypt.org/directory
@@ -15,11 +25,13 @@ letsencrypt:
     webroot-path = /var/lib/www
     agree-tos = True
     renew-by-default = True
+
   config_dir:
     path: /etc/letsencrypt
     user: root
     group: root
     mode: 755
+
   domainsets:
     www:
       - example.com
@@ -30,10 +42,16 @@ letsencrypt:
       - mail.example.com
     intranet:
       - intranet.example.com
+
+  # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
+  # run. For more fine grain control, consider placing scritps in the pre,
+  # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For
+  # more information, see: https://certbot.eff.org/docs/using.html#renewal
   post_renew:
     cmds:
       - service nginx reload
       - service haproxy reload
+
   cron:
     minute: 10
     hour: 2

--- a/pillar.example
+++ b/pillar.example
@@ -37,7 +37,7 @@ letsencrypt:
     intranet:
       - intranet.example.com
   # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
-  # run. For more fine grain control, consider placing scritps in the pre,
+  # run. For more fine grain control, consider placing scripts in the pre,
   # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For
   # more information, see: https://certbot.eff.org/docs/using.html#renewal
   post_renew:


### PR DESCRIPTION
This builds on my previous commit. The goals of this pull request are:
- Improved readability by moving comments before the option and wrapping them at 80 characters
- Made comments consistent between `pillar.example` and `letsencrypt/defaults.yaml`
- Added comment about renewal-hooks directories
  - [Renewal - User Guide — Certbot 0.29.0.dev0 documentation](https://certbot.eff.org/docs/using.html#renewal)