### PR TITLE
Update pillar.example to good-citizen defaults

### DIFF
--- a/letsencrypt/config.sls
+++ b/letsencrypt/config.sls
@@ -13,7 +13,10 @@ letsencrypt-config-directory:
 letsencrypt-config:
   file.managed:
     - name: {{ letsencrypt.config_dir.path }}/cli.ini
+    - template: jinja
+    - source: salt://letsencrypt/files/cli.ini.jinja
     - user: {{ letsencrypt.config_dir.user }}
     - group: {{ letsencrypt.config_dir.group }}
     - makedirs: true
-    - contents_pillar: letsencrypt:config
+    - context:
+        config: {{ letsencrypt.config | json }}

--- a/letsencrypt/defaults.yaml
+++ b/letsencrypt/defaults.yaml
@@ -17,6 +17,11 @@ letsencrypt:
     user: root
     group: root
     mode: 755
+  config:
+    agree-tos: true
+    keep-until-expiring: true
+    expand: true
+    max-log-backups: 0
   # The post_renew cmds are executed via renew_letsencrypt_cert.sh after every
   # run. For more fine grain control, consider placing scripts in the pre,
   # post, and/or deploy directories within /etc/letsencrypt/renewal-hooks/. For

--- a/letsencrypt/files/cli.ini.jinja
+++ b/letsencrypt/files/cli.ini.jinja
@@ -1,0 +1,11 @@
+########################################################################
+# File managed by Salt at <{{ source }}>.
+# Your changes will be overwritten.
+########################################################################
+{%- if config is string %}
+{{ config }}
+{%- else %}
+  {%- for k, v in config.items() %}
+{{ k }} = {{ v }}
+  {%- endfor %}
+{%- endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -21,7 +21,8 @@ letsencrypt:
     authenticator = webroot
     webroot-path = /var/lib/www
     agree-tos = True
-    renew-by-default = True
+    keep-until-expiring = True
+    expand = True
   config_dir:
     path: /etc/letsencrypt
     user: root

--- a/pillar.example
+++ b/pillar.example
@@ -15,14 +15,27 @@ letsencrypt:
   # have specific version of certbot you can enable it. The version value
   # should match a certbot/certbot branch.
   version: 0.30.x
-  config: |
-    server = https://acme-v01.api.letsencrypt.org/directory
-    email = webmaster@example.com
-    authenticator = webroot
-    webroot-path = /var/lib/www
-    agree-tos = True
-    keep-until-expiring = True
-    expand = True
+  # Any parameter from the cli can be specified in the config file
+  # check https://certbot.eff.org/docs/using.html#configuration-file
+  config:
+    server: https://acme-v01.api.letsencrypt.org/directory
+    email: webmaster@example.com
+    authenticator: webroot
+    webroot-path: /var/lib/www
+    agree-tos: true
+    keep-until-expiring: true
+    expand: true
+  # For backward compatibility, config can be passed as a string
+  # (although it's discouraged, as this format might be dropped in a future
+  # release)
+  # config: |
+  #   server = https://acme-v01.api.letsencrypt.org/directory
+  #   email = webmaster@example.com
+  #   authenticator = webroot
+  #   webroot-path = /var/lib/www
+  #   agree-tos = True
+  #   keep-until-expiring = True
+  #   expand = True
   config_dir:
     path: /etc/letsencrypt
     user: root

--- a/test/integration/deb/controls/letsencrypt_spec.rb
+++ b/test/integration/deb/controls/letsencrypt_spec.rb
@@ -14,6 +14,7 @@ describe file('/etc/letsencrypt/cli.ini') do
     should match 'server = https://acme-staging.api.letsencrypt.org/directory'
   end
   its('content') { should match 'authenticator = webroot' }
+  its('content') { should match 'File managed by Salt' }
 end
 
 describe file('/usr/bin/letsencrypt') do

--- a/test/integration/git/controls/letsencrypt_spec.rb
+++ b/test/integration/git/controls/letsencrypt_spec.rb
@@ -18,4 +18,5 @@ describe file('/etc/letsencrypt/cli.ini') do
     should match 'server = https://acme-staging.api.letsencrypt.org/directory'
   end
   its('content') { should match 'authenticator = standalone' }
+  its('content') { should match 'File managed by Salt' }
 end

--- a/test/integration/rpm/controls/letsencrypt_spec.rb
+++ b/test/integration/rpm/controls/letsencrypt_spec.rb
@@ -15,6 +15,7 @@ describe file('/etc/letsencrypt/cli.ini') do
     should match 'server = https://acme-staging.api.letsencrypt.org/directory'
   end
   its('content') { should match 'authenticator = webroot' }
+  its('content') { should match 'File managed by Salt' }
 end
 
 describe file('/usr/bin/letsencrypt') do

--- a/test/salt/pillar/rpm.sls
+++ b/test/salt/pillar/rpm.sls
@@ -3,13 +3,13 @@
 ---
 letsencrypt:
   use_package: true
-  config: |
-    server = https://acme-staging.api.letsencrypt.org/directory
-    email = saltstack-letsencrypt-formula@example.com
-    authenticator = webroot
-    webroot-path = /var/www/html
-    agree-tos = true
-    renew-by-default = true
+  config:
+    server: https://acme-staging.api.letsencrypt.org/directory
+    email: saltstack-letsencrypt-formula@example.com
+    authenticator: webroot
+    webroot-path: /var/www/html
+    agree-tos: true
+    renew-by-default: true
   domainsets:
     www:
       - letsencrypt-formula.example.com


### PR DESCRIPTION
Specifying `renew-by-default` in the config, regardless of True / False enables the flag. This causes certbot to force-renew on every timer run and means you will hit the rate-limit fairly quickly. A safer default is `keep-until-expiring` where the renew will only be done when it's actually advisable.

`expand` allows an expanded domain list to renew correctly without forking a new domainset. This is something that most users will want.