### PR TITLE
refactor: Use domains' setname as --cert-name option

### DIFF
--- a/letsencrypt/domains.sls
+++ b/letsencrypt/domains.sls
@@ -41,8 +41,8 @@
 # represent SubjectAlternativeNames
 create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}:
   cmd.run:
-    - unless: {{ check_cert_cmd }} {{ domainlist[0] }}
-    - name: {{ create_cert_cmd }} certonly --quiet -d {{ domainlist|join(' -d ') }} --non-interactive
+    - unless: {{ check_cert_cmd }} {{ setname }}
+    - name: {{ create_cert_cmd }} certonly --quiet --cert-name {{ setname }} -d {{ domainlist|join(' -d ') }} --non-interactive
       {% if not letsencrypt.use_package %}
     - cwd: {{ letsencrypt.cli_install_dir }}
       {% endif %}
@@ -70,14 +70,14 @@ letsencrypt-crontab-{{ setname }}-{{ domainlist[0] }}:
       - file: {{ renew_cert_cmd }}
       {% endif %}
 
-create-fullchain-privkey-pem-for-{{ domainlist[0] }}:
+create-fullchain-privkey-pem-for-{{ setname }}:
   cmd.run:
     - name: |
-        cat {{ letsencrypt.config_dir.path }}/live/{{ domainlist[0] }}/fullchain.pem \
-            {{ letsencrypt.config_dir.path }}/live/{{ domainlist[0] }}/privkey.pem \
-            > {{ letsencrypt.config_dir.path }}/live/{{ domainlist[0] }}/fullchain-privkey.pem && \
-        chmod 600 {{ letsencrypt.config_dir.path }}/live/{{ domainlist[0] }}/fullchain-privkey.pem
-    - creates: {{ letsencrypt.config_dir.path }}/live/{{ domainlist[0] }}/fullchain-privkey.pem
+        cat {{ letsencrypt.config_dir.path }}/live/{{ setname }}/fullchain.pem \
+            {{ letsencrypt.config_dir.path }}/live/{{ setname }}/privkey.pem \
+            > {{ letsencrypt.config_dir.path }}/live/{{ setname }}/fullchain-privkey.pem && \
+        chmod 600 {{ letsencrypt.config_dir.path }}/live/{{ setname }}/fullchain-privkey.pem
+    - creates: {{ letsencrypt.config_dir.path }}/live/{{ setname }}/fullchain-privkey.pem
     - require:
       - cmd: create-initial-cert-{{ setname }}-{{ domainlist | join('+') }}
 


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [X] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

Yes. 
The setname was not used before and the certificate path will not be the same.
The most obvious change that needs to be done is changing the pillar to match the first domain in a domain sets like the following:
```yaml
letsencrypt:
  domains:
    foo.example.com:
      - foo.example.com
```

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Certbot has the ability to name a certificate with the --cert-name option.

This allows us for instance to refers to this same setname to other
configuration and then further automate virtualhost creation in nginx or apache.


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

Here is an example that should write the certificates into `/etc/letsencrypt/live/foo/` path:
```yaml
letsencrypt:
  domains:
    foo:
      - foo.example.com
```
You might need to change the `.example.com` with something real if tested against a real ACME server (I've tested this change locally with a local [pebble server](https://github.com/letsencrypt/pebble)).


### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


